### PR TITLE
Fixed composer vendor name typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Eloquent meta provides an easy way to implement schemaless meta data stores for 
 Add the package via composer:
 
 ```php
-composer require boxedcode/laravel-eloquent-meta
+composer require boxed-code/laravel-eloquent-meta
 ```
 
 then add the following


### PR DESCRIPTION
Copying and pasting the instructions in the README causes the installation to fail due to a typo - "boxedcode" should be "boxed-code" as in composer.json.
